### PR TITLE
Resolves clock hand not spinning

### DIFF
--- a/templates/template.html
+++ b/templates/template.html
@@ -209,7 +209,7 @@
     </div>
   </footer>
   <script type="text/javascript">
-    { { javascript; } }
+    {{ javascript }}
   </script>
 </body>
 


### PR DESCRIPTION
Issue was automatic code formatter believing placeholder `{{javascript}}` inside a javascript tag was javascript and reformatting it to `{ { javascript; } }`